### PR TITLE
Fix mapping.

### DIFF
--- a/src/main/kotlin/com/example/demo/data/ParentWithList.kt
+++ b/src/main/kotlin/com/example/demo/data/ParentWithList.kt
@@ -11,6 +11,6 @@ data class ParentWithList(
     val pId: UUID?,
     val name: String,
 
-    @MappedCollection(idColumn = "p_id", keyColumn = "c_id")
+    @MappedCollection(idColumn = "p_id", keyColumn = "index")
     val children: List<Child>
 )

--- a/src/test/kotlin/com/example/demo/DemoApplicationTests.kt
+++ b/src/test/kotlin/com/example/demo/DemoApplicationTests.kt
@@ -47,7 +47,6 @@ class DemoApplicationTests {
     fun createTables() {
         jdbcTemplate.execute(
             """
-            
             CREATE TABLE IF NOT EXISTS parent
             (
                 p_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -57,9 +56,12 @@ class DemoApplicationTests {
             (
                 c_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                 name VARCHAR,
-                p_id UUID NOT NULL REFERENCES parent (p_id)
+                p_id UUID NOT NULL REFERENCES parent (p_id),
+                index INTEGER
             );
-            
+           
+            DELETE FROM child;
+            DELETE FROM parent;
         """.trimIndent()
         )
     }


### PR DESCRIPTION
This also required adding delete to the schema creation script, since the two aggregates map to the same tables, which results in unexpected child rows.

See https://github.com/spring-projects/spring-data-relational/issues/1316